### PR TITLE
fix: Inventory.Select checks for

### DIFF
--- a/osrs/interfaces/gametabs/inventory.simba
+++ b/osrs/interfaces/gametabs/inventory.simba
@@ -205,8 +205,9 @@ begin
       Break;
     end;
 
-  Mouse.Click(b, EMouseButton.LEFT);
-  Result := not wait or SleepUntil(Self.IsSelected(b), 50, RandomMode(800, 600, 1400));
+  Result := Self.Items.Interact(slot, 'Use');
+  if Result and wait then
+    Result := SleepUntil(Self.IsSelected(b), 50, RandomMode(800, 600, 1400));
 end;
 
 function TRSInventory.Select(item: TRSItem; wait: Boolean = False): Boolean; overload;

--- a/osrs/interfaces/iteminterface.simba
+++ b/osrs/interfaces/iteminterface.simba
@@ -313,3 +313,22 @@ begin
   Target.MouseClick(EMouseButton.LEFT);
   Result := True;
 end;
+
+function TRSItemInterface.Interact(slot: Integer; option: String = ''): Boolean; overload;
+var
+  box: TBox;
+begin
+  if (@Self.CheckFunction <> nil) and not Self.CheckFunction() then
+    Exit;
+    
+  if not Self.Slots^.IsUsed(slot) then Exit;
+  
+  box := Self.Slots^.Box(slot);
+  Mouse.Move(box);
+  
+  if (option <> '') and not SleepUntil(MainScreen.IsUpText(option), 20, 200) then
+    Exit(ChooseOption.Select(option));
+
+  Target.MouseClick(EMouseButton.LEFT);
+  Result := True;
+end;


### PR DESCRIPTION
`Select` failed to handle `Use`

```pascal
{$I WaspLib/osrs.simba}
begin
  Inventory.Open;
  Inventory.Combine('Battlestaff', 'Air orb');
end. 
```