### PR TITLE
feat: Load accounts from file

### DIFF
--- a/osrs/player.simba
+++ b/osrs/player.simba
@@ -112,6 +112,54 @@ begin
     raise GetDebugLn('Players', 'Invalid bank pin.');
 end;
 
+(*
+## Players.LoadAccounts
+```pascal
+procedure TRSPlayerArray.LoadAccounts();
+```
+Loads all account profiles from the accounts JSON files (0.json, 1.json, etc).
+*)
+procedure TRSPlayerArray.LoadAccounts();
+var
+  i, j, worldNum: Integer;
+  data, profile: TJSONItem;
+  path, username, password, pin, worldsStr: String;
+  worldStrs: TStringArray;
+  worlds: TIntegerArray;
+begin
+  // Load each account file in order
+  repeat
+    path := WLEnv.ConfigsDir + 'accounts' + PATH_SEP + ToStr(i) + '.json';
+    if not FileExists(path) then Break;
+    
+    data := new TJSONParser();
+    TJSONParser(data).Load(path);
+    
+    if not data.GetObject('profile', profile) then
+    begin
+      data.Destroy();
+      Inc(i);
+      Continue;
+    end;
+
+    profile.GetString('username', username);
+    profile.GetString('password', password);
+    profile.GetString('bankpin', pin);
+    profile.GetString('worlds', worldsStr);
+    
+    // Convert world string to integer array
+    worldStrs := worldsStr.Split(',');
+    for j := 0 to High(worldStrs) do
+      if (worldNum := StrToInt(worldStrs[j].Trim(), -1)) > 0 then
+        worlds += worldNum;
+
+    Self.Add(username, password, pin, worlds);
+    
+    data.Destroy();
+    Inc(i);
+  until False;
+end;
+
 var
 (*
 ## Players variable


### PR DESCRIPTION
@Torwent I leave the decision up to you where `LoadAccounts` should be called, automatically in some setup or devs do it manually. 
### Test
```pascal
{$I WaspLib/osrs.simba}

begin
  Players.LoadAccounts();
  
  WriteLn('Loaded accounts: ' + ToStr(Length(Players)));
  for PlayerIndex := 0 to High(Players) do
    WriteLn(ToStr(PlayerIndex) + ': ' + ToStr(Players[PlayerIndex]));
end.
```

