### PR TITLE
fix: set playerindex on form close

### DIFF
--- a/osrs.simba
+++ b/osrs.simba
@@ -36,7 +36,7 @@ just having {$INCLUDE_ONCE WaspLib/osr.simba}
 Summary: It includes this file until the current file is reached.
 }
 
-{$IFNDEF WL_PLAYER_INCLUDED}              {$INCLUDE_ONCE osrs/player.simba}
+{$IFNDEF WL_PLAYER_INCLUDED}              {$INCLUDE_ONCE osrs/player.simba} {$ENDIF}
 {$IFNDEF WL_BIOMETRICS_INCLUDED}          {$INCLUDE_ONCE osrs/antiban/biometrics.simba}
 
 {$IFNDEF WL_RSCLIENT_INCLUDED}            {$INCLUDE_ONCE osrs/rsclient.simba}
@@ -140,7 +140,7 @@ Summary: It includes this file until the current file is reached.
 {$IFNDEF WL_SETUP_INCLUDED}               {$INCLUDE_ONCE osrs/interfaces/setup.simba}
 {$IFNDEF WL_OVERRIDES_INCLUDED}           {$INCLUDE_ONCE osrs/overrides.simba}
 
-{$ENDIF}{$ENDIF}
+{$ENDIF}
 {$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}
 {$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}
 {$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}

--- a/osrs/interfaces/login/login.simba
+++ b/osrs/interfaces/login/login.simba
@@ -585,6 +585,10 @@ function TRSLogin.DoLogin(player: TRSPlayer = ['', '', '', [], True]): Boolean;
 var
   timeout: UInt64;
 begin
+  // If no player data provided, get it from Players array
+  if (player.Username = '') and (player.Password = '') and (player.Pin = '') and (Length(player.Worlds) = 0) then
+    player := Players.GetPlayer();
+    
   timeout := Time() + 40000;
 
   while not RSClient.IsLoggedIn() and not Lobby.IsOpen() do

--- a/osrs/interfaces/login/login.simba
+++ b/osrs/interfaces/login/login.simba
@@ -585,10 +585,6 @@ function TRSLogin.DoLogin(player: TRSPlayer = ['', '', '', [], True]): Boolean;
 var
   timeout: UInt64;
 begin
-  // If no player data provided, get it from Players array
-  if (player.Username = '') and (player.Password = '') and (player.Pin = '') and (Length(player.Worlds) = 0) then
-    player := Players.GetPlayer();
-    
   timeout := Time() + 40000;
 
   while not RSClient.IsLoggedIn() and not Lobby.IsOpen() do

--- a/osrs/player.simba
+++ b/osrs/player.simba
@@ -3,7 +3,7 @@
 Page dedicated to handling player accounts.
 *)
 {$DEFINE WL_PLAYER_INCLUDED}
-{$INCLUDE_ONCE WaspLib/osrs.simba}
+{$INCLUDE_ONCE WaspLib/utils.simba}
 
 var
 (*

--- a/utils.simba
+++ b/utils.simba
@@ -27,6 +27,7 @@
 {$IFNDEF WL_FORMUTILS_INCLUDED}       {$INCLUDE_ONCE utils/forms/formutils.simba}
 {$IFNDEF WL_DISCORD_INCLUDED}         {$INCLUDE_ONCE utils/discord.simba}
 {$IFNDEF WL_ACCOUNT_FORM_INCLUDED}    {$INCLUDE_ONCE utils/forms/account_form.simba}
+{$IFNDEF WL_PLAYER_INCLUDED}          {$INCLUDE_ONCE osrs/player.simba}{$ENDIF}
 {$IFNDEF WL_SCRIPTFORM_INCLUDED}      {$INCLUDE_ONCE utils/forms/scriptform.simba}
 
 {$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}{$ENDIF}

--- a/utils/forms/scriptform.simba
+++ b/utils/forms/scriptform.simba
@@ -78,7 +78,17 @@ end;
 ```
 *)
 procedure TScriptForm.OnStart(sender: TLazObject);
+var
+  selectedIndex: Integer;
 begin
+  selectedIndex := AccountForm.ProfileCombo.ItemIndex;
+  if (selectedIndex >= 0) and (selectedIndex < Length(AccountForm.Profiles)) then
+  begin
+    if Length(Players) = 0 then
+      Players.LoadAccounts();
+    PlayerIndex := selectedIndex;
+  end;
+  
   Self.Form.OnClose := nil;
   Self.Form.Close();
 end;


### PR DESCRIPTION
Sorry @Torwent but I had to do `{$IFNDEF WL_PLAYER_INCLUDED} {$INCLUDE_ONCE osrs/player.simba} {$ENDIF} ` , peanut brain could not figure out how to use `player.simba` inside `scriptform.simba` without `osrs.simba` without `osrs.simba` skipping includes and making forms look weird. 

### Test
```pascal
{$I WaspLib/osrs.simba}

var
  form: TScriptForm;
begin
  form.Setup('My Script');
  form.Run();
  Writeln('Playerindex: ', PlayerIndex);
  Writeln('Username: ', Players[PlayerIndex].Username);
  Writeln('Username: ', Players[PlayerIndex].Password);

  repeat
  if not RSClient.IsLoggedIn then
    Login.DoLogin(Players.GetPlayer());
  until RSClient.IsLoggedIn;
end.
```