### PR TITLE
Update scriptform.simba

### DIFF
--- a/utils/forms/scriptform.simba
+++ b/utils/forms/scriptform.simba
@@ -86,8 +86,11 @@ end;
 *)
 procedure TScriptForm.OnStart(sender: TLazObject);
 begin
-  TLazForm(sender).OnClose := nil;
-  TLazForm(sender).Close();
+  if (Self.Form <> nil) then
+  begin
+    Self.Form.OnClose := nil;
+    Self.Form.Close();
+  end;    
 
   if (Self.Goals.Actions <> nil) then
   begin


### PR DESCRIPTION
Address access violation:

Close the actual form instance in `TScriptForm.OnStart` instead of casting the button sender to a form.

Clicking 'start' on a form was leading to crashes, this addresses that bug.