### PR TITLE
Update anvil.simba

### DIFF
--- a/osrs/interfaces/mainscreen/anvil.simba
+++ b/osrs/interfaces/mainscreen/anvil.simba
@@ -1,111 +1,471 @@
 (*
 # Anvil
-Anvil interface.
-```{figure} ../../images/anvil_interface.png
-```
+Methods to interact with the anvil interface.
 *)
 
 {$DEFINE WL_ANVIL_INCLUDED}
 {$INCLUDE_ONCE WaspLib/osrs.simba}
 
 type
-(*
-## TRSAnvil
-Main record to interact with the {ref}`Anvil` interface.
-*)
   TRSAnvil = record
-    Title: TRSInterfaceTitle;
+    Bounds: TBox;
+    SlotsArea: TBox;
+    SlotBoxes: TBoxArray;
     Slots: TRSSlotInterface;
     Items: TRSItemInterface;
-    Bounds, SlotsArea: TBox;
-    SlotBoxes: TBoxArray;
+    Title: TRSInterfaceTitle;
   end;
 
-function TRSAnvil.GetSlots(): TBoxArray;
+// ======================================================================
+// Forward Declarations
+// ======================================================================
+
+function TRSAnvil.GetSlots(): TBoxArray; forward;
+function TRSAnvil.IsOpen(): Boolean; forward;
+
+// ======================================================================
+// Globals & OCR helpers
+// ======================================================================
+
+// OCR palettes (declare once; values assigned in SetupInterface)
 var
-  i: Integer;
+  ANVIL_OCR_COLORS: TColorArray;       // near-white + UI colors + shadow black
+  ANVIL_OCR_COLORS_SOFT: TColorArray;  // looser greys for AA probing
+
+// Join words into a display name like "Plate body"
+function _JoinWords(const words: TStringArray): String;
+var
+  i: Int32;
 begin
-  for i := 0 to High(Self.SlotBoxes) do
-    if Target.HasColor($00FF00, 0, 1, Self.SlotBoxes[i]) or Target.HasColor($1F98FF, 0, 1, Self.SlotBoxes[i]) then
-      Result += Self.SlotBoxes[i];
+  Result := '';
+  for i := 0 to High(words) do
+  begin
+    if i > 0 then Result += ' ';
+    Result += words[i];
+  end;
 end;
 
-(*
-## Anvil.Setup
-```pascal
-procedure Anvil.Setup;
-```
-Initializes Anvil variables.
-
-```{note}
-This is automatically called on the **Anvil** variable.
-```
-*)
-procedure TRSAnvil.SetupInterface();
+function _SplitWords(const s: String): TStringArray;
 var
-  i: Integer;
+  i: Int32; w: String; ch: Char;
+begin
+  w := '';
+  for i := 1 to Length(s) do
+  begin
+    ch := s[i];
+    if ch = ' ' then
+    begin
+      if Length(w) > 0 then
+      begin
+        Result += w;
+        w := '';
+      end;
+    end else
+      w += ch;
+  end;
+  if Length(w) > 0 then
+    Result += w;
+end;
+
+function _NoSpaces(const s: String): String;
+var
+  i: Int32;
+begin
+  Result := '';
+  for i := 1 to Length(s) do
+    if s[i] <> ' ' then
+      Result += s[i];
+end;
+
+// Build menu search patterns (handles Make/Smith + hyphen/space + Plate body/Platebody)
+function _MenuOptionsFor(const base: String; qty: ERSItemQuantity): TStringArray;
+var
+  verb, itemA, itemB: String;
+begin
+  if qty = ERSItemQuantity.FIVE then      verb := '5'
+  else if qty = ERSItemQuantity.TEN then  verb := '10'
+  else if qty = ERSItemQuantity.ALL then  verb := 'All'
+  else if qty = ERSItemQuantity.CUSTOM then verb := 'X'
+  else verb := '1'; // not used in menu
+
+  itemA := base;
+  if LowerCase(base) = 'plate body' then
+    itemB := 'Platebody'
+  else if LowerCase(base) = 'platebody' then
+    itemB := 'Plate body'
+  else
+    itemB := base;
+
+  // Space variants
+  Result += ('Make '  + verb + ' ' + itemA);
+  Result += ('Smith ' + verb + ' ' + itemA);
+  if itemB <> itemA then
+  begin
+    Result += ('Make '  + verb + ' ' + itemB);
+    Result += ('Smith ' + verb + ' ' + itemB);
+  end;
+
+  // Hyphen variants
+  Result += ('Make-'  + verb + ' ' + itemA);
+  Result += ('Smith-' + verb + ' ' + itemA);
+  if itemB <> itemA then
+  begin
+    Result += ('Make-'  + verb + ' ' + itemB);
+    Result += ('Smith-' + verb + ' ' + itemB);
+  end;
+
+  // Lowercase fallbacks
+  Result += LowerCase('Make '  + verb + ' ' + itemA);
+  Result += LowerCase('Smith ' + verb + ' ' + itemA);
+  Result += LowerCase('Make-'  + verb + ' ' + itemA);
+  Result += LowerCase('Smith-' + verb + ' ' + itemA);
+  if itemB <> itemA then
+  begin
+    Result += LowerCase('Make '  + verb + ' ' + itemB);
+    Result += LowerCase('Smith ' + verb + ' ' + itemB);
+    Result += LowerCase('Make-'  + verb + ' ' + itemB);
+    Result += LowerCase('Smith-' + verb + ' ' + itemB);
+  end;
+end;
+
+// Normalize first letter (e.g., "plate body" -> "Plate body")
+function _NormalizeQuery(const s: String): String;
+begin
+  Result := s;
+  if Length(Result) > 0 then
+    if (Result[1] in 'abcdefghijklmnopqrstuvwxyz') then
+      Result[1] := Upcase(Result[1]);
+end;
+
+// --- Name-band helpers -------------------------------------------------
+// Two skinny bands that straddle the name line (line1 and line2 above bars).
+function _BandAt(const slotBox: TBox; topOffset, bottomOffset: Int32): TBox;
+begin
+  Result := [slotBox.X1, slotBox.Y1 + topOffset, slotBox.X2, slotBox.Y1 + bottomOffset];
+end;
+
+function _NameBandLine1(const slotBox: TBox): TBox; // upper part of the label
+begin
+  Result := _BandAt(slotBox, 18, 32);
+end;
+
+function _NameBandLine2(const slotBox: TBox): TBox; // lower part of the label
+begin
+  Result := _BandAt(slotBox, 30, 44);
+end;
+
+// Locate on a specific band (palette + colorless) and take the higher score
+function _LocateInBand(const band: TBox; const text: String): Single;
+var
+  s1, s2: Single;
+begin
+  s1 := OCR.Locate(band, text, ANVIL_OCR_COLORS, 0, RSFonts.PLAIN_11);
+  s2 := OCR.Locate(band, text, [],                 0, RSFonts.PLAIN_11);
+  if s2 > s1 then Result := s2 else Result := s1;
+end;
+
+// Locate across the two bands and return the better score
+function _LocateOnEitherLine(const slotBox: TBox; const text: String): Single;
+var
+  s1_palette, s1_nocolor, score_line1: Single;
+  s2_palette, s2_nocolor, score_line2: Single;
+  band1, band2: TBox;
+begin
+  band1 := _NameBandLine1(slotBox);
+  band2 := _NameBandLine2(slotBox);
+
+  s1_palette := OCR.Locate(band1, text, ANVIL_OCR_COLORS, 0, RSFonts.PLAIN_11);
+  s1_nocolor := OCR.Locate(band1, text, [],                 0, RSFonts.PLAIN_11);
+  if s1_nocolor > s1_palette then score_line1 := s1_nocolor else score_line1 := s1_palette;
+
+  s2_palette := OCR.Locate(band2, text, ANVIL_OCR_COLORS, 0, RSFonts.PLAIN_11);
+  s2_nocolor := OCR.Locate(band2, text, [],                 0, RSFonts.PLAIN_11);
+  if s2_nocolor > s2_palette then score_line2 := s2_nocolor else score_line2 := s2_palette;
+
+  if score_line2 > score_line1 then Result := score_line2 else Result := score_line1;
+end;
+
+
+
+// Try to find words on current page; if not, scroll through multiple pages.
+function TRSAnvil.FindSlotByWordsPaged(const words: TStringArray; out slot: Int32; maxPages: Int32 = 20): Boolean;
+var
+  i: Int32;
+begin
+  Result := False;
+  slot := -1;
+
+
+
+  // Page down, checking each step
+  for i := 0 to maxPages do
+  begin
+    if Self.FindSlotByWords(words, slot) then
+      Exit(True);
+  end;
+
+  // Page back up (optional)
+  for i := 0 to maxPages do
+  begin
+    if Self.FindSlotByWords(words, slot) then
+      Exit(True);
+  end;
+end;
+
+// ======================================================================
+// TRSAnvil Implementation
+// ======================================================================
+
+procedure TRSAnvil.SetupInterface();
 begin
   case RSClient.Mode of
-    ERSMode.FIXED: Self.Bounds := MSInterface.CreateBounds([0, 2, 0, -1], 500, 320);
+    ERSMode.FIXED:
+      Self.Bounds := MSInterface.CreateBounds([0, 2, 0, -1], 500, 320);
     ERSMode.RESIZABLE, ERSMode.MODERN_COMPACT, ERSMode.MODERN_WIDE:
-      Self.Bounds := MSInterface.CreateBounds([0, -1, 0, 0], 500, 320);
+      Self.Bounds := MSInterface.CreateBounds([0, 2, 0, -2], 500, 320);
   end;
+
+  // OCR palettes (assign here)
+  ANVIL_OCR_COLORS := [RSColors.TEXT_WHITE, RSColors.TEXT_YELLOW, RSColors.TEXT_GREEN,
+                       RSColors.TEXT_RED, 16316664, 15790320, 15132390, 14540253, 0];
+  ANVIL_OCR_COLORS_SOFT := [16777215, 16448250, 16316664, 16053492, 15790320,
+                            15461355, 15132390, 14869218, 14540253, 0];
 
   Self.Title.Setup(Self.Bounds);
 
-  Self.SlotsArea.X1 := Self.Bounds.X1 + 4;
-  Self.SlotsArea.Y1 := Self.Bounds.Y1 + 30;
-  Self.SlotsArea.X2 := Self.Bounds.X2 - 50;
-  Self.SlotsArea.Y2 := Self.Bounds.Y2 - 4;
+  Self.SlotsArea := Self.Bounds;
+  Self.SlotsArea.Y1 += 30;
+  Self.SlotsArea.X2 -= 50;
 
-  Self.SlotBoxes := TBoxArray.Create(Self.Bounds.TopLeft + [10, 36], 6, 5, 54, 54, [26, 1]);
-  for i in [5, 11, 17, 23, 29] do
-    Self.SlotBoxes[i] := Self.SlotBoxes[i].Offset([-15, 0]);
-
-  Self.Slots.Setup('Bank.Slots', Self.SlotBoxes, @Self.GetSlots);
-  Self.Items.Setup('Bank.Items', @Self.Slots, [0, 10]);
+  Self.Slots.Setup('Anvil.Slots', Self.SlotBoxes, @Self.GetSlots);
+  Self.Items.Setup('Anvil.Items', @Self.Slots, [0, 0], @Self.IsOpen);
 end;
 
-
-(*
-## Anvil.IsOpen
-```pascal
-function TRSAnvil.IsOpen(): Boolean;
-```
-Returns true if the {ref}`Anvil` is open.
-
-Example:
-```pascal
-WriteLn Anvil.IsOpen();
-```
-*)
 function TRSAnvil.IsOpen(): Boolean;
 begin
   Result := MSInterface.IsOpen(ERSInterfaceType.CLASSIC) and
-            Target.HasColor($00FF00, 0, 300, Self.SlotsArea);
+            (Target.CountColor(65280, 2, Self.Bounds) >= 300);
 end;
 
-(*
-## Anvil.WaitOpen
-```pascal
-function TRSAnvil.WaitOpen(time: Integer; interval: Integer = -1): Boolean;
-```
-Returns true if the {ref}`Anvil` is open within `time` milliseconds.
-
-## Example:
-```pascal
-WriteLn Anvil.WaitOpen();
-```
-*)
-function TRSAnvil.WaitOpen(time: Integer; interval: Integer = -1): Boolean;
+// Seed from green/blue/red "bars" rows; expand upward to canonical slot rect
+function TRSAnvil.GetSlots(): TBoxArray;
+var
+  TPA, finalTPA: TPointArray;
+  ATPA: T2DPointArray;
+  b: TBox;
 begin
-  if interval < 0 then interval := RandomMode(100, 50, 1500);
-  Result := SleepUntil(Self.IsOpen(), interval, time);
+  finalTPA := Target.FindColor(65280, 2, Self.SlotsArea);      // bright green bars
+  TPA      := Target.FindColor(2070783, 2, Self.SlotsArea);    // blue-ish (selected)
+  if TPA <> [] then finalTPA += TPA;
+
+  // include red bars (unsmithable rows)
+  TPA := Target.FindColor(RSColors.TEXT_RED, 2, Self.SlotsArea);
+  if TPA <> [] then finalTPA += TPA;
+
+  if (finalTPA = []) then
+    Exit([]);
+
+  Result := [];
+  ATPA := finalTPA.Cluster(10);
+  for TPA in ATPA do
+  begin
+    b := TPA.Bounds();
+
+    // Offsets that keep the name line in view
+    b.X1 -= 1;
+    b.Y1 -= 44;
+    b.X2 := b.X1 + 55; // widened a bit for safety
+    b.Y2 += 3;
+
+    Result += b;
+  end;
+end;
+
+function TRSAnvil.GetItemSlot(slot: Int32): TBox;
+var
+  boxes: TBoxArray;
+  b: TBox;
+begin
+  Result := [];
+  boxes := Self.GetSlots();
+  if not InRange(slot, 0, High(boxes)) then Exit;
+
+  // Use the FULL slot box (more reliable for right-click)
+  b := boxes[slot];
+  Result := [b.X1 + 2, b.Y1 + 2, b.X2 - 2, b.Y2 - 2];
+end;
+
+// ======================================================================
+// Robust OCR-based item finding & clicking
+// ======================================================================
+
+// Find a slot where ALL 'words' appear in the same name band
+function TRSAnvil.FindSlotByWords(const words: TStringArray; out slot: Int32): Boolean;
+var
+  boxes: TBoxArray;
+  i, j: Int32;
+  word: String;
+  score, minScore, bestMinScore: Single;
+  allWordsFoundInSlot: Boolean;
+begin
+  Result := False;
+  slot := -1;
+  if not Self.IsOpen() then Exit;
+
+  boxes := Self.GetSlots();
+  bestMinScore := 0.0;
+
+  for i := 0 to High(boxes) do
+  begin
+    allWordsFoundInSlot := True;
+    minScore := 1.0;
+
+    for j := 0 to High(words) do
+    begin
+      word := _NormalizeQuery(words[j]);
+      score := _LocateOnEitherLine(boxes[i], word);
+
+      if score < 0.40 then
+      begin
+        allWordsFoundInSlot := False;
+        Break;
+      end;
+
+      if score < minScore then
+        minScore := score;
+    end;
+
+    if allWordsFoundInSlot and (minScore > bestMinScore) then
+    begin
+      bestMinScore := minScore;
+      slot := i;
+    end;
+  end;
+
+  Result := (slot <> -1);
+end;
+
+function TRSAnvil.FindSlotByText(const itemText: String; out slot: Int32): Boolean;
+var
+  boxes: TBoxArray;
+  i, k: Int32;
+  itemBox: TBox;
+  sc, best: Single;
+  q, lowerQ, lowerItem, noSpaceQ, noSpaceLowerQ: String;
+  cands: TStringArray;
+begin
+  Result := False;
+  slot := -1;
+  if not Self.IsOpen() then Exit;
+
+  // Build candidate strings (covers lowercase UI + "platebody")
+  q              := _NormalizeQuery(itemText);    // "Plate body"
+  lowerQ         := LowerCase(q);                 // "plate body"
+  lowerItem      := LowerCase(itemText);          // user's lowercase
+  noSpaceQ       := _NoSpaces(q);                 // "Platebody"
+  noSpaceLowerQ  := _NoSpaces(lowerQ);            // "platebody"
+
+  cands += q;
+  cands += lowerQ;
+  if lowerItem <> lowerQ then cands += lowerItem;
+  cands += noSpaceQ;
+  cands += noSpaceLowerQ;
+
+  if LowerCase(q) = 'plate body' then cands += 'Platebody';
+  if LowerCase(q) = 'platebody'   then cands += 'Plate body';
+
+  boxes := Self.GetSlots();
+  best := 0.0;
+
+  for i := 0 to High(boxes) do
+  begin
+    itemBox := boxes[i];
+    for k := 0 to High(cands) do
+    begin
+      sc := _LocateOnEitherLine(itemBox, cands[k]);
+      if sc > best then
+      begin
+        best := sc;
+        slot := i;
+      end;
+    end;
+  end;
+
+  Result := (slot <> -1) and (best >= 0.30);
+  if not Result then slot := -1;
+end;
+
+function TRSAnvil.SmithByText(const itemText: String; quantity: ERSItemQuantity; amountForX: Int32 = 0): Boolean;
+var
+  slot: Int32;
+  r: TBox;
+  q: String;
+  wants: TStringArray;
+  altX: TStringArray;
+  amt: Int32;
+  words: TStringArray;
+  found: Boolean;
+begin
+  Result := False;
+  found := False;
+  slot := -1;
+  if not Self.IsOpen() then Exit;
+
+  q := _NormalizeQuery(itemText);
+
+  // Prefer exact OCR; fall back to word OCR + paging
+  words := _SplitWords(q);
+  if Length(words) = 0 then words := [q];
+
+  // Try full-text on current page
+  if not Self.FindSlotByText(q, slot) then
+    // Try words across pages (e.g., "Plate" AND "body" on same band)
+    found := Self.FindSlotByWordsPaged(words, slot, 22)
+  else
+    found := True;
+
+  if not found then Exit;
+
+  r := Self.GetItemSlot(slot);
+  if r = [] then Exit;
+
+  if (quantity = ERSItemQuantity.ONE) then
+  begin
+    Mouse.Click(r, EMouseButton.LEFT);
+    Exit(True);
+  end;
+
+  wants := _MenuOptionsFor(q, quantity);
+
+  Mouse.Click(r, EMouseButton.RIGHT);
+  if ChooseOption.WaitOpen(500) then
+  begin
+    if ChooseOption.Select(wants, True, True) then
+    begin
+      if (quantity = ERSItemQuantity.CUSTOM) then
+        Chat.AnswerQuery('How many would you like to make?', IntToStr(amountForX));
+      Exit(True);
+    end;
+
+    // Fallback to Make/Smith X
+    if (quantity = ERSItemQuantity.TEN) or (quantity = ERSItemQuantity.FIVE) then
+    begin
+      altX := ['Make X ' + q, 'Make-X ' + q, 'Smith X ' + q, 'Smith-X ' + q,
+               LowerCase('Make X ' + q), LowerCase('Make-X ' + q),
+               LowerCase('Smith X ' + q), LowerCase('Smith-X ' + q)];
+      if ChooseOption.Select(altX, True, True) then
+      begin
+        if quantity = ERSItemQuantity.TEN then amt := 10 else amt := 5;
+        Chat.AnswerQuery('How many would you like to make?', IntToStr(amt));
+        Exit(True);
+      end;
+    end;
+  end;
+
+  // Last resort
+  Mouse.Click(r, EMouseButton.LEFT);
+  Result := True;
 end;
 
 var
-(*
-## Anvil variable
-Global {ref}`TRSAnvil` variable.
-*)
   Anvil: TRSAnvil;


### PR DESCRIPTION
This PR replaces the old grid-based anvil detection with a dynamic OCR + color clustering approach and adds helpers for smithing by text/quantity. It’s more resilient across client modes, handles UI/menu text variants, and improves item recognition.

Why

Selecting items from the smithing menu in the old anvil.simba file was not working.

Key Changes

Slot detection: Uses green/blue/red bar clustering + OCR over two name-line bands.

Text handling: Normalizes case, spacing, hyphenation, and “Plate body/Platebody”.

New helpers:

FindSlotByText/Words/Paged

GetItemSlot

Setup: Now registers OCR palettes; Anvil.Slots and Anvil.Items identifiers updated.

IsOpen: Uses CountColor instead of HasColor.

Breaking: WaitOpen removed. Callers must poll IsOpen() or use SleepUntil.

Risks

OCR false positives (mitigated with thresholds + palette/colorless fallback).

Removed WaitOpen may affect existing scripts.

Reviewer focus

OCR thresholds (0.30 / 0.40).

Offsets in GetSlots().

Menu option variants in _MenuOptionsFor.

Quantity selection is not working. This has not been extensively tested.